### PR TITLE
Add experimental Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ OS X: `brew install boost`
 
 Ubuntu: `apt-get install libboost-all-dev`
 
+Windows: Install the latest version of [`Boost`](https://www.boost.org/) then set the `BOOST_ROOT` environment variable to point to its folder.
+
 Then:
 
 ```shell
@@ -142,8 +144,11 @@ Pull requests are welcome, please file any issues you encounter.
 
 ## Changelog
 
+### v2.5.0 2020-04-17
+* Added experimental support for Windows.
+
 ### v2.4.0 2020-03-23
-* Added `RingBuffer.reset()` method for .
+* Added `RingBuffer.reset()` method.
 
 ### v2.3.0 2020-03-22
 * Added `concatenate` function for joining multiple arbitrary Python objects that support the buffer protocol.

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,12 @@ except ImportError:
 
 DIR = os.path.dirname(__file__)
 MODULE_PATH = os.path.join(DIR, 'src', 'ringbuf')
+try:
+    BOOST_PATH = os.environ['BOOST_ROOT']
+except KeyError:
+    BOOST_PATH = ''
+    if 'Windows' in platform.platform():
+        raise KeyError('Please install Boost and specify its location using the "BOOST_ROOT" environmental variable')
 
 
 def get_args():
@@ -89,11 +95,11 @@ def get_package_data():
 def get_ext_modules():
     args = get_args()
     ext_modules = []
-    include_dirs = [os.path.abspath(d) for d in (DIR, MODULE_PATH)]
+    include_dirs = [os.path.abspath(d) for d in (DIR, MODULE_PATH, BOOST_PATH)]
 
     for path in itertools.chain(
             glob.glob(os.path.join(MODULE_PATH, '*.pyx'))):
-        module_name = path.replace(MODULE_PATH, 'ringbuf').replace('/', '.').replace('.pyx', '')
+        module_name = path.replace(MODULE_PATH, 'ringbuf').replace('/', '.').replace('\\', '.').replace('.pyx', '')
         sources = [path]
         extra_compile_args = []
         extra_link_args = []
@@ -128,7 +134,7 @@ def get_ext_modules():
 
 setup(
     name='ringbuf',
-    version='2.4.0',
+    version='2.5.0',
     description='A lock-free ring buffer for Python and Cython.',
     long_description=get_readme(),
     long_description_content_type="text/markdown",
@@ -154,6 +160,7 @@ setup(
     classifiers=[
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: POSIX :: Linux',
+        'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Programming Language :: Python :: Implementation :: CPython',


### PR DESCRIPTION
Backslashes in Windows file paths must be accounted for. Also, the file path to Boost must be provided explicitly (can be streamlined through an environent variable). After fixing these issues, the package will compile on Windows given a valid path is set for the "BOOST_ROOT" environment variable.